### PR TITLE
I1 u5 ps

### DIFF
--- a/app/controllers/ports_controller.rb
+++ b/app/controllers/ports_controller.rb
@@ -26,6 +26,12 @@ class PortsController < ApplicationController
     render :show
   end
 
+  def delete
+    @port = Port.find(params[:id])
+    @port.destroy
+    redirect_to '/ports'
+  end
+
   private
 
   def port_params

--- a/app/controllers/ports_controller.rb
+++ b/app/controllers/ports_controller.rb
@@ -17,7 +17,13 @@ class PortsController < ApplicationController
   end
 
   def edit
+    @port = Port.find(params[:id])
+  end
 
+  def update
+    @port = Port.find(params[:id])
+    @port.update(port_params)
+    render :show
   end
 
   private

--- a/app/controllers/ports_controller.rb
+++ b/app/controllers/ports_controller.rb
@@ -16,6 +16,10 @@ class PortsController < ApplicationController
     redirect_to '/ports'
   end
 
+  def edit
+
+  end
+
   private
 
   def port_params

--- a/app/views/ports/edit.html.erb
+++ b/app/views/ports/edit.html.erb
@@ -1,0 +1,15 @@
+<%= form_tag "/ports/#{@port.id}", method: :patch do %>
+  <%= label_tag :name, 'Port Name' %>
+  <%= text_field_tag :name %><br/>
+
+  <%= label_tag :dock_count, 'Dock Count' %>
+  <%= number_field_tag :dock_count, 0, min: 0 %><br/>
+
+  <%= label_tag 'Panamax Capable (Greater than 12.56 meters in depth)' %><br/>
+  <%= radio_button_tag :panamax, "true" %>
+  <%= label_tag :panamax_true, "True" %>
+  <%= radio_button_tag :panamax, "false" %>
+  <%= label_tag :panamax_false, "False" %><br/>
+
+  <%= submit_tag 'Update' %>
+<% end %>

--- a/app/views/ports/show.html.erb
+++ b/app/views/ports/show.html.erb
@@ -1,6 +1,7 @@
 <h1><%= @port.name %></h1>
 <p>
-  <%= link_to("Update Port","/ports/#{@port.id}/edit") %>
+  <%= link_to "Update Port", "/ports/#{@port.id}/edit"  %>
+  <%= link_to "Delete Port", "/ports/#{@port.id}", method: :delete  %><br>
   Panamax Capable: <%= @port.panamax %><br>
   Dock Count: <%= @port.dock_count %><br>
 </p>

--- a/app/views/ports/show.html.erb
+++ b/app/views/ports/show.html.erb
@@ -1,5 +1,6 @@
 <h1><%= @port.name %></h1>
 <p>
+  <%= link_to("Update Port","/ports/#{@port.id}/edit") %>
   Panamax Capable: <%= @port.panamax %><br>
   Dock Count: <%= @port.dock_count %><br>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get '/ports/:id', to: 'ports#show'
   post '/ports', to: 'ports#create'
   get '/ports/:id/edit', to: 'ports#edit'
+  patch '/ports/:id', to: 'ports#update'
 
   get '/ships', to: 'ships#index'
   get '/ships/:id', to: 'ships#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get '/ports/new', to: 'ports#new'
   get '/ports/:id', to: 'ports#show'
   post '/ports', to: 'ports#create'
+  get '/ports/:id/edit', to: 'ports#edit'
+
   get '/ships', to: 'ships#index'
   get '/ships/:id', to: 'ships#show'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   post '/ports', to: 'ports#create'
   get '/ports/:id/edit', to: 'ports#edit'
   patch '/ports/:id', to: 'ports#update'
+  delete '/ports/:id', to: 'ports#delete'
 
   get '/ships', to: 'ships#index'
   get '/ships/:id', to: 'ships#show'

--- a/spec/features/ports/edit_spec.rb
+++ b/spec/features/ports/edit_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'As a visitor when I visit a port edit page' do
+  describe 'When I fill out the form with updated information And I click the update button' do
+    it "Then I am redirected to the port's show page where I see the port's updated info" do
+      la = Port.create(name: 'Los Angeles', panamax: true, dock_count: 5)
+
+      visit "/ports/#{la.id}/edit"
+
+      fill_in 'Name', with: 'Port Royale'
+      fill_in 'Dock Count', with: '3'
+      choose 'False'
+
+      click_on 'Update'
+
+      expect(current_path).to eq("/ports/#{la.id}")
+      expect(page).to have_content('Port Royale')
+      expect(page).to have_content("Panamax Capable: false")
+      expect(page).to have_content("Dock Count: 3")
+    end
+  end
+end

--- a/spec/features/ports/show_spec.rb
+++ b/spec/features/ports/show_spec.rb
@@ -25,7 +25,7 @@ describe 'As a visitor when I visit a port show page' do
 
       visit "/ports/#{la.id}"
 
-      click 'Update Port'
+      click_on 'Update Port'
 
       expect(current_path).to eql("/ports/#{la.id}/edit")
     end

--- a/spec/features/ports/show_spec.rb
+++ b/spec/features/ports/show_spec.rb
@@ -18,4 +18,16 @@ describe 'As a visitor when I visit a port show page' do
     expect(page).to have_content("Panamax Capable: #{ny.panamax}")
     expect(page).to have_content("Dock Count: #{ny.dock_count}")
   end
+
+  describe "When I click the link 'Update Port'" do
+    it "Then I am taken to '/ports/:id/edit'" do
+      la = Port.create(name: 'Los Angeles', panamax: true, dock_count: 5)
+
+      visit "/ports/#{la.id}"
+
+      click 'Update Port'
+
+      expect(current_path).to eql("/ports/#{la.id}/edit")
+    end
+  end
 end

--- a/spec/features/ports/show_spec.rb
+++ b/spec/features/ports/show_spec.rb
@@ -30,4 +30,17 @@ describe 'As a visitor when I visit a port show page' do
       expect(current_path).to eql("/ports/#{la.id}/edit")
     end
   end
+
+  describe "When I click the link 'Delete Port'" do
+    it "I am redirected to '/ports' where I no longer see the port" do
+      la = Port.create(name: 'Los Angeles', panamax: true, dock_count: 5)
+
+      visit "/ports/#{la.id}"
+
+      click_on 'Delete Port'
+
+      expect(current_path).to eql("/ports")
+      expect(page).to_not have_content('Los Angeles')
+    end
+  end
 end


### PR DESCRIPTION
This PR meets the requirements for user story 5. AKA allows users to delete a specific port
 by clicking a 'Delete Port' button on that port's show page.
```
As a visitor
When I visit a parent show page
Then I see a link to delete the parent
When I click the link "Delete Parent"
Then a 'DELETE' request is sent to '/parents/:id',
the parent is deleted, and all child records are deleted
and I am redirected to the parent index page where I no longer see this parent
```