### PR TITLE
I2 u14 ps

### DIFF
--- a/app/controllers/ports_controller.rb
+++ b/app/controllers/ports_controller.rb
@@ -3,7 +3,7 @@ class PortsController < ApplicationController
   skip_before_action :load_port, only: [:index, :new, :create]
 
   def index
-    @ports = Port.all.sorted_recent_at_top
+    @ports = Port.all
   end
 
   def show

--- a/app/controllers/ships_controller.rb
+++ b/app/controllers/ships_controller.rb
@@ -3,7 +3,7 @@ class ShipsController < ApplicationController
   skip_before_action :load_ship, only: [:index]
 
   def index
-    @ships = Ship.all.sorted_recent_at_top
+    @ships = Ship.all
   end
 
   def show

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  def self.sorted_recent_at_top
+  def self.recent_at_top
     return order(created_at: :desc)
   end
 end

--- a/app/models/port.rb
+++ b/app/models/port.rb
@@ -4,4 +4,8 @@ class Port < ApplicationRecord
   def ship_count
     ships.count
   end
+
+  def self.panamax_capable_at_top
+    return where(panamax: :true) + where(panamax: :false)
+  end
 end

--- a/app/models/ship.rb
+++ b/app/models/ship.rb
@@ -1,3 +1,7 @@
 class Ship < ApplicationRecord
   belongs_to :port
+
+  def self.floating_at_top
+    return where(floating: :true) + where(floating: :false)
+  end
 end

--- a/app/views/ports/index.html.erb
+++ b/app/views/ports/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Ports</h1>
 
 <ul>
-  <% @ports.each do |port| %>
+  <% @ports.recent_at_top.panamax_capable_at_top.each do |port| %>
     <li class="port-<%= port.id %>"><%= port.name %> <%= port.created_at.strftime("Created on %m/%d/%Y") %></li>
   <% end %>
 </ul>

--- a/app/views/ships/index.html.erb
+++ b/app/views/ships/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Ships</h1>
 
 <ul>
-  <% @ships.each do |ship| %>
+  <% @ships.recent_at_top.each do |ship| %>
     <li class="ship-<%= ship.id %>">
       <%= ship.name %><br/>
       <%= ship.created_at.strftime("Created on %m/%d/%Y") %>

--- a/spec/features/ports/index_spec.rb
+++ b/spec/features/ports/index_spec.rb
@@ -25,8 +25,7 @@ describe 'as a visitor when I visit the ports index page' do
     end
   end
 
-  it 'I see the records that have a `true` above/before the records that have a false' do
+  it 'I see the records that have panamax `true` above/before the records that have a false' do
     expect(@la.name).to appear_before(@ny.name)
-    expect(@orleans.name).to appear_before(@ny.name)
   end
 end

--- a/spec/features/ports/index_spec.rb
+++ b/spec/features/ports/index_spec.rb
@@ -15,11 +15,6 @@ describe 'as a visitor when I visit the ports index page' do
     expect(page).to have_content(@orleans.name)
   end
 
-  it 'I see the most recently created records in order by recency from top to bottom' do
-    expect(@ny.name).to appear_before(@orleans.name)
-    expect(@orleans.name).to appear_before(@la.name)
-  end
-
   it 'I see the DateTime(s) next to each of the records in a reasonably formatted manner' do
     within(".port-#{@ny.id}") do
       expect(page).to have_content("Created on 12/09/2020")
@@ -28,5 +23,10 @@ describe 'as a visitor when I visit the ports index page' do
     within(".port-#{@la.id}") do
       expect(page).to have_content("Created on 12/07/2020")
     end
+  end
+
+  it 'I see the records that have a `true` above/before the records that have a false' do
+    expect(@la.name).to appear_before(@ny.name)
+    expect(@orleans.name).to appear_before(@ny.name)
   end
 end

--- a/spec/features/ships/index_spec.rb
+++ b/spec/features/ships/index_spec.rb
@@ -21,11 +21,6 @@ describe 'As a visitor' do
       expect(page).to have_content("Crew Count: #{@battleship.crew_count}")
     end
 
-    it 'I see the most recently created records in order by recency from top to bottom' do
-      expect(@battleship.name).to appear_before(@destroyer.name)
-      expect(@destroyer.name).to appear_before(@wreck.name)
-    end
-
     it 'I see the DateTime(s) next to each of the records in a reasonably formatted manner' do
       within(".ship-#{@battleship.id}") do
         expect(page).to have_content("Created on 12/10/2020")
@@ -34,6 +29,10 @@ describe 'As a visitor' do
       within(".ship-#{@wreck.id}") do
         expect(page).to have_content("Created on 12/08/2020")
       end
+    end
+
+    it 'I see the records that have floating: `true` above/before the records that have a false' do
+      expect(@battleship.name).to appear_before(@wreck.name)
     end
   end
 end

--- a/spec/models/application_record.rb
+++ b/spec/models/application_record.rb
@@ -2,19 +2,21 @@ require 'rails_helper'
 
 describe ApplicationRecord do
   describe 'class helper methods' do
-    it 'sorted_recent_at_top' do
-      la = Port.create!(name: 'Los Angeles', panamax: true, dock_count: 5, created_at: 'Mon, 07 Dec 2020 01:00:00 UTC +00:00')
-      orleans = Port.create!(name: 'New Orleans', panamax: true, dock_count: 2, created_at: 'Tues, 08 Dec 2020 01:00:00 UTC +00:00')
-      ny = Port.create!(name: 'New York', panamax: false, dock_count: 3, created_at: 'Wed, 09 Dec 2020 01:00:00 UTC +00:00')
+    describe 'recent_at_top' do
+      it 'recent_at_top' do
+        la = Port.create!(name: 'Los Angeles', panamax: true, dock_count: 5, created_at: 'Mon, 07 Dec 2020 01:00:00 UTC +00:00')
+        orleans = Port.create!(name: 'New Orleans', panamax: true, dock_count: 2, created_at: 'Tues, 08 Dec 2020 01:00:00 UTC +00:00')
+        ny = Port.create!(name: 'New York', panamax: false, dock_count: 3, created_at: 'Wed, 09 Dec 2020 01:00:00 UTC +00:00')
 
-      wreck = la.ships.create!(name: 'Shipwreck', floating: false, crew_count: 0, created_at: 'Tues, 08 Dec 2020 01:00:00 UTC +00:00')
-      battleship = la.ships.create!(name: 'Battleship', floating: true, crew_count: 1500, created_at: 'Thurs, 10 Dec 2020 01:00:00 UTC +00:00')
-      destroyer = la.ships.create!(name: 'Destroyer', floating: true, crew_count: 100, created_at: 'Weds, 9 Dec 2020 01:00:00 UTC +00:00')
+        wreck = la.ships.create!(name: 'Shipwreck', floating: false, crew_count: 0, created_at: 'Tues, 08 Dec 2020 01:00:00 UTC +00:00')
+        battleship = la.ships.create!(name: 'Battleship', floating: true, crew_count: 1500, created_at: 'Thurs, 10 Dec 2020 01:00:00 UTC +00:00')
+        destroyer = la.ships.create!(name: 'Destroyer', floating: true, crew_count: 100, created_at: 'Weds, 9 Dec 2020 01:00:00 UTC +00:00')
 
-      expect(Port.all.sorted_recent_at_top).to eq([ny, orleans, la])
-      expect([la,ny].sorted_recent_at_top).to eq([ny,la])
-      expect(Ship.all.sorted_recent_at_top).to eq([battleship, destroyer, wreck])
-      expect([wreck,battleship].sorted_recent_at_top).to eq([battleship, wreck])
+        expect(Port.all.recent_at_top).to eq([ny, orleans, la])
+        expect([la,ny].recent_at_top).to eq([ny,la])
+        expect(Ship.all.recent_at_top).to eq([battleship, destroyer, wreck])
+        expect([wreck,battleship].recent_at_top).to eq([battleship, wreck])
+      end
     end
   end
 end

--- a/spec/models/port_spec.rb
+++ b/spec/models/port_spec.rb
@@ -5,6 +5,18 @@ describe Port do
     it { should have_many :ships }
   end
 
+  describe 'class helper methods' do
+    describe 'panamax_capable_at_top' do
+      it 'should return all the ports sorted with panamax capable ports at the top' do
+        la = Port.create!(name: 'Los Angeles', panamax: true, dock_count: 5)
+        ny = Port.create!(name: 'New York', panamax: false, dock_count: 3)
+        orleans = Port.create!(name: 'New Orleans', panamax: true, dock_count: 2)
+
+        expect(Port.panamax_capable_at_top).to eq([la, orleans, ny])
+      end
+    end
+  end
+
   describe 'helper methods' do
     describe 'ship_count' do
       it 'should return the number of ships that belong to this port' do

--- a/spec/models/ship_spec.rb
+++ b/spec/models/ship_spec.rb
@@ -4,4 +4,17 @@ describe Ship do
   describe 'relationships' do
     it { should belong_to :port }
   end
+
+  describe 'class helper methods' do
+    describe 'floating_at_top' do
+      it 'should return all the ships sorted with floating ships at the top' do
+        la = Port.create!(name: 'Los Angeles', panamax: true, dock_count: 5)
+        wreck = la.ships.create!(name: 'Shipwreck', floating: false, crew_count: 0)
+        battleship = la.ships.create!(name: 'Battleship', floating: true, crew_count: 1500)
+        destroyer = la.ships.create!(name: 'Destroyer', floating: true, crew_count: 100)
+
+        expect(Ship.all.floating_at_top).to eq([battleship, destroyer, wreck])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Meets requirements for user story 14:

```
As a visitor
When I visit the '/parents' or '/child_table_name' index page for a parent or child table that has a boolean column
I see the records that have a `true` above/before the records that have a false
```

I don't like how I made this work with active record. I think this can be refactored to something else in the future.

```
// models/port
def self.panamax_capable_at_top
    where(panamax: :true) + where(panamax: :false)
end

// models/ship
def self.floating_at_top
    where(floating: :true) + where(floating: :false)
end
```